### PR TITLE
Fix cycle counts and parameters for JP [HL], JR n8, and SCF.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -237,7 +237,7 @@ generateOpcode(0xd2, 'JP', ['NC', 'n16'], [16, 12]);
 generateOpcode(0xca, 'JP', ['Z', 'n16'], [16, 12]);
 generateOpcode(0xda, 'JP', ['C', 'n16'], [16, 12]);
 generateOpcode(0xc3, 'JP', ['n16'], 16);
-generateOpcode(0xe9, 'JP', ['[HL]'], 16);
+generateOpcode(0xe9, 'JP', ['[HL]'], 4);
 
 // JR
 generateInstruction('JR', 'Jump to address relative to the current address.', generateFlags(undefined, undefined, undefined, undefined));
@@ -245,7 +245,7 @@ generateOpcode(0x20, 'JR', ['NZ', 'n8'], [12, 8]);
 generateOpcode(0x30, 'JR', ['NC', 'n8'], [12, 8]);
 generateOpcode(0x28, 'JR', ['Z', 'n8'], [12, 8]);
 generateOpcode(0x38, 'JR', ['C', 'n8'], [12, 8]);
-generateOpcode(0x18, 'JR', ['n16'], 12);
+generateOpcode(0x18, 'JR', ['n8'], 12);
 
 // LD
 generateInstruction('LD', 'Load value into destination.', generateFlags(undefined, undefined, undefined, undefined));
@@ -400,7 +400,7 @@ generateOpcode(0xde, 'SBC', ['n8'], 8);
 
 // SCF
 generateInstruction('SCF', 'Set Carry Flag.', generateFlags(undefined, 0, 0, 1));
-generateOpcode(0x37, 'SCF', ['n8'], 8);
+generateOpcode(0x37, 'SCF', [], 4);
 
 // SET
 generateInstruction('SET', 'Set bit on value.', generateFlags(undefined, undefined, undefined, undefined));


### PR DESCRIPTION
This change fixes the cycle counts & parameters for a few instructions. Here's a text summary:
- JP [HL] lasts 4 cycles (before: 16)
- JR n8 takes n8 as a parameter (before: n16)
- SCF takes no parameter (before: n8) & lasts 4 cycles (before: 8)

Found these while using WasmBoy for a disassembly project, very thankful for these software contributions!

References:
- https://gbdev.io/pandocs/CPU_Instruction_Set.html
- https://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html
- https://rgbds.gbdev.io/docs/v0.5.2/gbz80.7
- https://meganesulli.com/generate-gb-opcodes/